### PR TITLE
Bring back NDK toolchain because of performance issues

### DIFF
--- a/.github/workflows/build_piccap.yml
+++ b/.github/workflows/build_piccap.yml
@@ -26,7 +26,7 @@ jobs:
       run: npm install
 
     - name: Download webOS NDK
-      run: wget -q https://github.com/webosbrew/meta-lg-webos-ndk/releases/download/1.0.g-rev.4/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -P ${{github.workspace}}/temp
+      run: wget -q https://github.com/webosbrew/meta-lg-webos-ndk/releases/download/1.0.g-rev.5/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -P ${{github.workspace}}/temp
 
     - name: Install webOS NDK
       run: chmod 755 ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh && sudo ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -y

--- a/.github/workflows/build_piccap.yml
+++ b/.github/workflows/build_piccap.yml
@@ -24,17 +24,15 @@ jobs:
     - name: Install dependencies
       working-directory: ${{github.workspace}}
       run: npm install
- 
-    - name: Download and unpack toolchain
-      working-directory: /opt
-      run: wget -q -O toolchain.tar.gz https://github.com/openlgtv/buildroot-nc4/releases/download/webos-9f5b1a1/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz && tar -xf toolchain.tar.gz
 
-    - name: Relocate toolchain
-      working-directory: /opt/arm-webos-linux-gnueabi_sdk-buildroot
-      run: ./relocate-sdk.sh
+    - name: Download webOS NDK
+      run: wget -q https://github.com/webosbrew/meta-lg-webos-ndk/releases/download/1.0.g-rev.4/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -P ${{github.workspace}}/temp
 
-    - name: Setup Env
-      run: env -i bash -c 'export CMAKE_TOOLCHAIN_FILE=/opt/arm-webos-linux-gnueabi_sdk-buildroot/share/buildroot/toolchainfile.cmake && env' >> $GITHUB_ENV
+    - name: Install webOS NDK
+      run: chmod 755 ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh && sudo ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -y
+
+    - name: Initialize NDK Environments
+      run: env -i bash -c '. /opt/webos-sdk-x86_64/1.0.g/environment-setup-armv7a-neon-webos-linux-gnueabi && env' >> $GITHUB_ENV
 
     - name: Check CMAKE Version
       run: which cmake && cmake --version


### PR DESCRIPTION
See also https://github.com/webosbrew/hyperion-webos/pull/96
Fixes very slow performance on all TVs. 
Kind of addresses this issue: https://github.com/webosbrew/hyperion-webos/issues/94. But we should not close it yet, because renicing process might be still useful.
Tested on TVs down to webOS 3.4