### PR TITLE
Use buildroot-nc4 as toolchain again

### DIFF
--- a/.github/workflows/build_piccap.yml
+++ b/.github/workflows/build_piccap.yml
@@ -5,6 +5,12 @@ on:
   pull_request:
   workflow_dispatch:
 
+env:
+  TOOLCHAIN_URL: https://github.com/openlgtv/buildroot-nc4/releases/download/webos-c592d84/arm-webos-linux-gnueabi_sdk-buildroot.tar.gz
+  TOOLCHAIN_SHA256: be5b4249177fc31b3f0120106c761f42ade54fd609a3bd090852899bbdd680b9
+  TOOLCHAIN_DIR: /opt/arm-webos-linux-gnueabi_sdk-buildroot
+  TOOLCHAIN_FILE: /opt/arm-webos-linux-gnueabi_sdk-buildroot/share/buildroot/toolchainfile.cmake
+
 jobs:
   build-all:
     runs-on: ubuntu-latest
@@ -25,14 +31,20 @@ jobs:
       working-directory: ${{github.workspace}}
       run: npm install
 
-    - name: Download webOS NDK
-      run: wget -q https://github.com/webosbrew/meta-lg-webos-ndk/releases/download/1.0.g-rev.5/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -P ${{github.workspace}}/temp
+    - name: Download and unpack toolchain
+      working-directory: /opt
+      run: |
+        wget -q -O toolchain.tar.gz ${TOOLCHAIN_URL}
+        echo "${TOOLCHAIN_SHA256} toolchain.tar.gz"|sha256sum -c -
+        tar xf toolchain.tar.gz
 
-    - name: Install webOS NDK
-      run: chmod 755 ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh && sudo ${{github.workspace}}/temp/webos-sdk-x86_64-armv7a-neon-toolchain-1.0.g.sh -y
+    - name: Relocate toolchain
+      working-directory: ${{ env.TOOLCHAIN_DIR }}
+      run: |
+        ./relocate-sdk.sh
 
-    - name: Initialize NDK Environments
-      run: env -i bash -c '. /opt/webos-sdk-x86_64/1.0.g/environment-setup-armv7a-neon-webos-linux-gnueabi && env' >> $GITHUB_ENV
+    - name: Setup Env
+      run: env -i bash -c 'export CMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_FILE && env' >> $GITHUB_ENV
 
     - name: Check CMAKE Version
       run: which cmake && cmake --version

--- a/.github/workflows/build_piccap.yml
+++ b/.github/workflows/build_piccap.yml
@@ -44,7 +44,7 @@ jobs:
         ./relocate-sdk.sh
 
     - name: Setup Env
-      run: env -i bash -c 'export CMAKE_TOOLCHAIN_FILE=$TOOLCHAIN_FILE && env' >> $GITHUB_ENV
+      run: env -i bash -c 'export CMAKE_TOOLCHAIN_FILE=/opt/arm-webos-linux-gnueabi_sdk-buildroot/share/buildroot/toolchainfile.cmake && env' >> $GITHUB_ENV
 
     - name: Check CMAKE Version
       run: which cmake && cmake --version

--- a/README.md
+++ b/README.md
@@ -64,6 +64,14 @@ You will also need `clang-format-14` if you want to contribute.
 ### How to build  
 We have tried to make build proccess as easy as possible. After building all files can be found in `./build`.
 ```
+# Setup buildroot-nc4 (needed for hyperion-webos)
+cd /desired/path
+wget -O toolchain.tar.gz $TOOLCHAIN_URL_FROM_RELEASES
+tar -xvzf toolchain.tar.gz
+rm toolchain.tar.gz
+arm-webos-linux-gnueabi_sdk-buildroot/relocate-sdk.sh
+export CMAKE_TOOLCHAIN_FILE=/desired/path/arm-webos-linux-gnueabi_sdk-buildroot/share/buildroot/toolchainfile.cmake
+
 # Clone project and submodules
 git clone --recursive https://github.com/TBSniller/piccap.git
 cd ./piccap


### PR DESCRIPTION
We can go back to buildroot: https://github.com/webosbrew/hyperion-webos/pull/98 & https://github.com/webosbrew/hyperion-webos/pull/97