### PR TITLE
Nv12

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,11 +137,9 @@
                 <div class="checkboxes checklabel blueMode">
                   <label for="checkSettingsAutostart">Autostart<input type="checkbox" id="checkSettingsAutostart"/></label><br/>
                   <label for="checkSettingsVSync">VSync<input type="checkbox" id="checkSettingsVSync"/></label>
-                  <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
-               </div>
-             </li>
-           </ul><br/>
-         </div>
+                </div>
+              </li>
+            </ul><br/>
         </div>
         <div class="settingItems settingItemsAdv blueMode" id="settingItemsAdv">
           <ul>
@@ -195,6 +193,9 @@
                  <label for="checkSettingsNoPowerstate">Disable powerstate check<input type="checkbox" id="checkSettingsNoPowerstate"/></label>
                </div>
              </li>
+           </ul><br/>
+         </div>
+       </div>
         <div class="btns blueMode">
           <button onclick="serviceSaveSettings()" id="btnSettingsSave">Save</button>
           <button onclick="serviceResetSettings()" id="btnSettingsReset">Reset</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -194,7 +194,7 @@
                </div>
              </li>
              <div class="checkboxes blueMode">
-                 <label for="checkSettingsNV12">Enable nv12<input type="checkbox" id="checkSettingsNV12"/></label>
+                 <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
                </div>
              </li>
            </ul><br/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -191,7 +191,10 @@
              <li>
                <div class="checkboxes blueMode">
                  <label for="checkSettingsNoPowerstate">Disable powerstate check<input type="checkbox" id="checkSettingsNoPowerstate"/></label>
-                 <label for="checkSettingsNV12">NV12<input type="checkbox" id="checkSettingsNV12"/></label>
+               </div>
+             </li>
+             <div class="checkboxes blueMode">
+                 <label for="checkSettingsNV12">Enable nv12<input type="checkbox" id="checkSettingsNV12"/></label>
                </div>
              </li>
            </ul><br/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,6 +137,7 @@
                 <div class="checkboxes checklabel blueMode">
                   <label for="checkSettingsAutostart">Autostart<input type="checkbox" id="checkSettingsAutostart"/></label><br/>
                   <label for="checkSettingsVSync">VSync<input type="checkbox" id="checkSettingsVSync"/></label>
+                  <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
                 </div>
               </li>
             </ul><br/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -137,11 +137,7 @@
                 <div class="checkboxes checklabel blueMode">
                   <label for="checkSettingsAutostart">Autostart<input type="checkbox" id="checkSettingsAutostart"/></label><br/>
                   <label for="checkSettingsVSync">VSync<input type="checkbox" id="checkSettingsVSync"/></label>
-                </div>
-              </li>
-            </ul><br/>
-          <div class="checkboxes blueMode">
-                 <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
+                  <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
                </div>
              </li>
            </ul><br/>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -140,6 +140,12 @@
                 </div>
               </li>
             </ul><br/>
+          <div class="checkboxes blueMode">
+                 <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
+               </div>
+             </li>
+           </ul><br/>
+         </div>
         </div>
         <div class="settingItems settingItemsAdv blueMode" id="settingItemsAdv">
           <ul>
@@ -193,13 +199,6 @@
                  <label for="checkSettingsNoPowerstate">Disable powerstate check<input type="checkbox" id="checkSettingsNoPowerstate"/></label>
                </div>
              </li>
-             <div class="checkboxes blueMode">
-                 <label for="checkSettingsnv12">nv12<input type="checkbox" id="checkSettingsnv12"/></label>
-               </div>
-             </li>
-           </ul><br/>
-         </div>
-       </div>
         <div class="btns blueMode">
           <button onclick="serviceSaveSettings()" id="btnSettingsSave">Save</button>
           <button onclick="serviceResetSettings()" id="btnSettingsReset">Reset</button>

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -191,6 +191,7 @@
              <li>
                <div class="checkboxes blueMode">
                  <label for="checkSettingsNoPowerstate">Disable powerstate check<input type="checkbox" id="checkSettingsNoPowerstate"/></label>
+                 <label for="checkSettingsNV12">NV12<input type="checkbox" id="checkSettingsNV12"/></label>
                </div>
              </li>
            </ul><br/>

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -297,9 +297,9 @@ window.serviceResetSettings = () => {
     height: 180,
     quirks: 0,
 
-    vsync: true,
+    vsync: false,
     autostart: false,
-    nv12: false,
+    nv12: true,
   };
   logIt(config);
 

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -229,6 +229,7 @@ function getSettings() {
           document.getElementById('checkSettingsAutostart').checked = result.autostart;
           document.getElementById('checkSettingsNoHDR').checked = result.nohdr;
           document.getElementById('checkSettingsNoPowerstate').checked = result.nopowerstate;
+          document.getElementById('checkSettingsNV12').checked = result.nv12;
 
           logIt('Loading settings done!');
           document.getElementById('txtInfoState').innerHTML = 'Settings loaded';
@@ -298,6 +299,7 @@ window.serviceResetSettings = () => {
 
     vsync: true,
     autostart: false,
+    nv12: false,
   };
   logIt(config);
 

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -389,7 +389,7 @@ window.serviceSaveSettings = () => {
     autostart: document.getElementById('checkSettingsAutostart').checked,
     nohdr: document.getElementById('checkSettingsNoHDR').checked,
     nopowerstate: document.getElementById('checkSettingsNoPowerstate').checked,
-    nv12: document.getElementById('checkSettingsNV12').checked,
+    nv12: document.getElementById('checkSettingsnv12').checked,
 };
 
   logIt(`Config: ${JSON.stringify(config)}`);

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -388,6 +388,7 @@ window.serviceSaveSettings = () => {
     autostart: document.getElementById('checkSettingsAutostart').checked,
     nohdr: document.getElementById('checkSettingsNoHDR').checked,
     nopowerstate: document.getElementById('checkSettingsNoPowerstate').checked,
+    nv12: document.getElementById('checkSettingsNV12').checked,
 
   };
 

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -229,7 +229,7 @@ function getSettings() {
           document.getElementById('checkSettingsAutostart').checked = result.autostart;
           document.getElementById('checkSettingsNoHDR').checked = result.nohdr;
           document.getElementById('checkSettingsNoPowerstate').checked = result.nopowerstate;
-          document.getElementById('checkSettingsNV12').checked = result.nv12;
+          document.getElementById('checkSettingsnv12').checked = result.nv12;
 
           logIt('Loading settings done!');
           document.getElementById('txtInfoState').innerHTML = 'Settings loaded';

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -297,7 +297,7 @@ window.serviceResetSettings = () => {
     height: 180,
     quirks: 0,
 
-    vsync: false,
+    vsync: true,
     autostart: false,
     nv12: true,
   };

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -299,7 +299,6 @@ window.serviceResetSettings = () => {
 
     vsync: true,
     autostart: false,
-    nv12: false,
   };
   logIt(config);
 
@@ -391,8 +390,7 @@ window.serviceSaveSettings = () => {
     nohdr: document.getElementById('checkSettingsNoHDR').checked,
     nopowerstate: document.getElementById('checkSettingsNoPowerstate').checked,
     nv12: document.getElementById('checkSettingsNV12').checked,
-
-  };
+};
 
   logIt(`Config: ${JSON.stringify(config)}`);
 

--- a/frontend/js/servicecalls.js
+++ b/frontend/js/servicecalls.js
@@ -299,6 +299,7 @@ window.serviceResetSettings = () => {
 
     vsync: true,
     autostart: false,
+    nv12: false,
   };
   logIt(config);
 


### PR DESCRIPTION
NV12 settings selection implementation, with current hyperion-webos/Submodules from https://github.com/webosbrew/hyperion-webos

In the new hyperion-webos, the backends have been extended to include nv12 video format, so that NV12/YUV can also be passed on to the Hyperion or HyperHDR instead of RGB. 
As a result, I have added a nv12 selection checkbox to the UI and linked the hyperion-webos to the latest build. 

![PicCap_nv12](https://github.com/user-attachments/assets/a647e617-9637-4bf0-b68f-cb0de58eb0a4)
