### PR TITLE
Update iconColor in appinfo.json

### DIFF
--- a/frontend/appinfo.json
+++ b/frontend/appinfo.json
@@ -10,6 +10,6 @@
   "largeIcon": "assets/logo_big.png",
   "splashBackground": "assets/splash_1080p.png",
   "bgImage": "assets/splash_1080p.png",
-  "iconColor": "black",
+  "iconColor": "#000000",
   "supportGIP": true
 }


### PR DESCRIPTION
webOS 25 fails to render iconColor stated as color name (i.e. "black"), hex color code is required.
<img width="2560" height="1440" alt="image" src="https://github.com/user-attachments/assets/8a45b48c-0f0d-48d4-b592-0f511148b6ec" />
